### PR TITLE
Allow more than 2 maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,14 @@
   },
   "dependencies": {
     "@beyonk/svelte-mapbox": "^8.1.4",
+    "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@googlemaps/js-api-loader": "^1.13.10",
     "@mapbox/mapbox-gl-geocoder": "^4.7.4",
     "deep-equal": "^2.0.5",
     "lodash.throttle": "^4.1.1",
     "mapbox-gl": "^1.13.1",
-    "sirv-cli": "^1.0.0"
+    "sirv-cli": "^1.0.0",
+    "svelte-fa": "^2.4.0"
   },
   "main": "dist/bundle.js"
 }

--- a/src/components/GoogleMap.svelte
+++ b/src/components/GoogleMap.svelte
@@ -15,9 +15,11 @@
   export let showCollisions;
   export let showBoundaries;
   export let mapStyle;
+  export let numberOfMaps;
 
   let mapId;
   let googleMapsAPIKey;
+  let currentNumberOfMaps = 0;
   configStore.subscribe(value => ({ googleMapsAPIKey } = value));
 
   $: if (mapStyle) ({ mapId } = mapStyle);
@@ -38,6 +40,20 @@
   // We check map and mapViewProps here to ensure this reacts to changes to
   // either
   $: if (map && mapViewProps) updateMapFromProps();
+
+  // Resize the map when adding more maps and changing container size
+  $: {
+    if (map && currentNumberOfMaps !== numberOfMaps) {
+      const container = document.getElementById(id);
+      if (container) {
+        const resizeObserver = new ResizeObserver(() => {
+          google.maps.event.trigger(map, 'resize');
+          currentNumberOfMaps = numberOfMaps;
+        });
+        resizeObserver.observe(container);
+      }
+    }
+  }
 
   const getCurrentMapView = () => {
     return {

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -2,8 +2,10 @@
   import GoogleMap from './GoogleMap.svelte';
   import MapboxGlMap from './MapboxGlMap.svelte';
   import MapLabel from './MapLabel.svelte';
+  import { maps as mapsStore } from '../stores';
 
   export let map;
+  export let numberOfMaps;
   let MapComponent;
 
   $: switch (map.type) {
@@ -14,6 +16,15 @@
     default:
       MapComponent = MapboxGlMap;
   }
+
+  const removeMap = () => {
+    mapsStore.update(current => {
+      const next = current
+        .filter((m, i) => i !== map.index)
+        .map((item, i) => ({ ...item, index: i }));
+      return next;
+    });
+  };
 </script>
 
 <div class="map">
@@ -26,8 +37,18 @@
     on:mapMove
   />
 
-  <div class={`map-label-container map-label-container-${map.index}`}>
-    <MapLabel index={map.index} name={map.name} />
+  <div
+    id={map.id}
+    class={`map-label-container ${
+      numberOfMaps === 2 ? `map-label-container-${map.index}` : ''
+    }`}
+  >
+    <MapLabel
+      index={map.index}
+      name={map.name}
+      onClose={removeMap}
+      disableClose={numberOfMaps <= 2}
+    />
   </div>
 </div>
 
@@ -35,16 +56,17 @@
   .map {
     height: 100%;
     width: 100%;
+    position: relative;
   }
 
   .map-label-container {
     position: absolute;
-    left: 1em;
+    right: 1em;
     bottom: 2em;
   }
 
-  .map-label-container-1 {
-    left: unset;
-    right: 1em;
+  .map-label-container-0 {
+    right: unset;
+    left: 1em;
   }
 </style>

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -29,30 +29,32 @@
   };
 </script>
 
-<div class="map">
-  <svelte:component
-    this={MapComponent}
-    index={map.index}
-    id={`${map.id}-${map.index}`}
-    mapStyle={map}
-    {numberOfMaps}
-    {...$$restProps}
-    on:mapMove
-  />
-  <div
-    id={map.id}
-    class={`map-label-container ${
-      numberOfMaps === 2 ? `map-label-container-${map.index}` : ''
-    } ${themeLabel}`}
-  >
-    <MapLabel
+{#key `${map.id}-${map.index}`}
+  <div class="map">
+    <svelte:component
+      this={MapComponent}
       index={map.index}
-      name={map.name}
-      onClose={removeMap}
-      disableClose={numberOfMaps <= 2}
+      id={`${map.id}-${map.index}`}
+      mapStyle={map}
+      {numberOfMaps}
+      {...$$restProps}
+      on:mapMove
     />
+    <div
+      id={map.id}
+      class={`map-label-container ${
+        numberOfMaps === 2 ? `map-label-container-${map.index}` : ''
+      } ${themeLabel}`}
+    >
+      <MapLabel
+        index={map.index}
+        name={map.name}
+        onClose={removeMap}
+        disableClose={numberOfMaps <= 2}
+      />
+    </div>
   </div>
-</div>
+{/key}
 
 <style>
   .map {

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -6,6 +6,8 @@
 
   export let map;
   export let numberOfMaps;
+  export let themeLabel = '';
+
   let MapComponent;
 
   $: switch (map.type) {
@@ -33,15 +35,15 @@
     index={map.index}
     id={`${map.id}-${map.index}`}
     mapStyle={map}
+    {numberOfMaps}
     {...$$restProps}
     on:mapMove
   />
-
   <div
     id={map.id}
     class={`map-label-container ${
       numberOfMaps === 2 ? `map-label-container-${map.index}` : ''
-    }`}
+    } ${themeLabel}`}
   >
     <MapLabel
       index={map.index}
@@ -68,5 +70,13 @@
   .map-label-container-0 {
     right: unset;
     left: 1em;
+  }
+
+  .map-label-offset {
+    position: absolute;
+    margin-top: 48px;
+    left: 0;
+    right: 0;
+    bottom: unset;
   }
 </style>

--- a/src/components/MapControls.svelte
+++ b/src/components/MapControls.svelte
@@ -87,13 +87,11 @@
         </label>
       </div>
     </div>
-    <!-- --------------------------------------------------------- -->
     <div class="control-section">
-      <!-- TODO better styling -->
-      <!-- MAX OUT AT 9? -->
-      <button on:click={addMapPane}> Add a pane </button>
+      <button on:click={addMapPane} disabled={maps.length >= 8}>
+        Add a map
+      </button>
     </div>
-    <!-- --------------------------------------------------------- -->
   </div>
   {#if mapStateValidationMessages.length > 0}
     <div class="validation-messages">

--- a/src/components/MapControls.svelte
+++ b/src/components/MapControls.svelte
@@ -42,6 +42,15 @@
     }
     dispatch('mapState', { options });
   };
+
+  const addMapPane = () => {
+    mapsStore.update(current => {
+      let lastMap = current[current.length - 1];
+      lastMap = { ...lastMap, index: lastMap.index + 1 };
+      const next = current.concat([lastMap]);
+      return next;
+    });
+  };
 </script>
 
 <div class="map-controls">
@@ -51,7 +60,7 @@
     </div>
 
     <div class="control-section">
-      <ViewModeControl on:viewMode mode={viewMode} />
+      <ViewModeControl on:viewMode mode={viewMode} mapsNum={maps.length} />
     </div>
 
     <div class="control-section">
@@ -78,6 +87,13 @@
         </label>
       </div>
     </div>
+    <!-- --------------------------------------------------------- -->
+    <div class="control-section">
+      <!-- TODO better styling -->
+      <!-- MAX OUT AT 9? -->
+      <button on:click={addMapPane}> Add a pane </button>
+    </div>
+    <!-- --------------------------------------------------------- -->
   </div>
   {#if mapStateValidationMessages.length > 0}
     <div class="validation-messages">

--- a/src/components/MapLabel.svelte
+++ b/src/components/MapLabel.svelte
@@ -1,11 +1,18 @@
 <script>
+  import { faXmark } from '@fortawesome/free-solid-svg-icons';
+  import Fa from 'svelte-fa/src/fa.svelte';
   import MapStyleInput from './MapStyleInput.svelte';
 
   export let index;
   export let name;
+  export let onClose;
+  export let disableClose;
 </script>
 
 <div class="map-label">
+  <button class="close-button" on:click={onClose} disabled={disableClose}>
+    <Fa icon={faXmark} />
+  </button>
   <div class="map-name">{name}</div>
   <MapStyleInput {index} />
 </div>
@@ -23,5 +30,24 @@
   .map-name {
     font-size: 1.25em;
     font-weight: bold;
+  }
+
+  .close-button {
+    background-color: transparent;
+    border: none;
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 6px;
+  }
+
+  .close-button:hover {
+    cursor: pointer;
+    color: black;
+  }
+
+  .close-button:disabled {
+    cursor: not-allowed;
+    color: lightgray;
   }
 </style>

--- a/src/components/MapStyleInput.svelte
+++ b/src/components/MapStyleInput.svelte
@@ -15,9 +15,11 @@
   let branch;
 
   mapsStore.subscribe(maps => {
-    branch = maps[index].branch;
-    name = maps[index].name;
-    url = maps[index].url;
+    if (maps[index]) {
+      branch = maps[index].branch;
+      name = maps[index].name;
+      url = maps[index].url;
+    }
   });
 
   let stylePresets;

--- a/src/components/MapStyleInput.svelte
+++ b/src/components/MapStyleInput.svelte
@@ -15,10 +15,11 @@
   let branch;
 
   mapsStore.subscribe(maps => {
-    if (maps[index]) {
-      branch = maps[index].branch;
-      name = maps[index].name;
-      url = maps[index].url;
+    const map = maps.find(m => m.index === index);
+    if (map) {
+      branch = map.branch;
+      name = map.name;
+      url = map.url;
     }
   });
 
@@ -28,32 +29,40 @@
   stylePresetsStore.subscribe(value => (stylePresets = value));
   configStore.subscribe(value => ({ branchPattern } = value));
 
-  let stylePresetOption = {};
-  $: stylePresetOption = stylePresets && stylePresets.find(s => s.url === url);
-
-  let selected = {
-    name,
-    dropdownType: 'custom',
-    url,
-  };
+  let selected;
   let textInput = url;
+  let dropdownOptions = {};
+
+  const getStylePresetOption = () => {
+    return stylePresets && stylePresets.find(s => s.url === url);
+  };
 
   const setSelected = () => {
+    const stylePresetOption = getStylePresetOption();
     if (stylePresetOption) {
       selected = { ...stylePresetOption, dropdownType: 'preset' };
       textInput = '';
-    }
-    if (branch) {
+    } else if (branch) {
       selected = {
         name,
         dropdownType: 'branch',
         url,
       };
       textInput = branch;
+    } else {
+      selected = {
+        name,
+        dropdownType: 'custom',
+        url,
+      };
+      textInput = url;
     }
+    dropdownOptions = getDropdownOptions();
   };
 
-  $: if (stylePresets) setSelected();
+  $: if (url) {
+    setSelected();
+  }
 
   let localUrl = '';
   let focused = false;
@@ -195,8 +204,6 @@
     }
   };
 
-  let dropdownOptions = {};
-
   const getDropdownOptions = () => {
     const options = {};
     if (stylePresets.length) {
@@ -227,8 +234,6 @@
     ];
     return options;
   };
-
-  $: if (stylePresets) dropdownOptions = getDropdownOptions();
 
   // This runs only on mount to check for localhost in url
   poll(url);

--- a/src/components/MapStyleInput.svelte
+++ b/src/components/MapStyleInput.svelte
@@ -140,7 +140,8 @@
     const { dropdownType } = selected;
     let nextLocalUrl =
       dropdownType === 'branch'
-        ? createBranchUrl(localUrl, selected.id)
+        ? // TODO We should sort out selected.id and selected.name here, this works but isn't clear
+          createBranchUrl(localUrl, selected.id || selected.name)
         : localUrl;
     if (selected?.url === nextLocalUrl) return;
     if (nextLocalUrl.includes('localhost')) {

--- a/src/components/MapStyleInput.svelte
+++ b/src/components/MapStyleInput.svelte
@@ -10,12 +10,13 @@
 
   export let index;
 
+  let map;
   let url;
   let name;
   let branch;
 
   mapsStore.subscribe(maps => {
-    const map = maps.find(m => m.index === index);
+    map = maps.find(m => m.index === index);
     if (map) {
       branch = map.branch;
       name = map.name;
@@ -60,7 +61,7 @@
     dropdownOptions = getDropdownOptions();
   };
 
-  $: if (url) {
+  $: if (map) {
     setSelected();
   }
 

--- a/src/components/MapboxGlMap.svelte
+++ b/src/components/MapboxGlMap.svelte
@@ -2,7 +2,7 @@
   import deepEqual from 'deep-equal';
   import { config as configStore } from '../stores';
   import throttle from 'lodash.throttle';
-  import { createEventDispatcher, onMount } from 'svelte';
+  import { createEventDispatcher, onMount, onDestroy } from 'svelte';
   import mapboxgl from 'mapbox-gl';
   import 'mapbox-gl/dist/mapbox-gl.css';
 
@@ -47,12 +47,13 @@
   // Show tile boundaries on the map as desired
   $: if (map) map.showTileBoundaries = showBoundaries;
 
+  // Resize the map when adding more maps and changing container size
   $: {
     if (map && currentNumberOfMaps !== numberOfMaps) {
       map.once('render', () => {
         const container = document.getElementById(id);
         if (container) {
-          const resizeObserver = new ResizeObserver(entries => {
+          const resizeObserver = new ResizeObserver(() => {
             map.resize({ resize: true });
             currentNumberOfMaps = numberOfMaps;
           });
@@ -112,6 +113,12 @@
         handleMove(e);
       }
     });
+  });
+
+  onDestroy(() => {
+    if (map) {
+      map.remove();
+    }
   });
 </script>
 

--- a/src/components/MapboxGlMap.svelte
+++ b/src/components/MapboxGlMap.svelte
@@ -53,7 +53,7 @@
         const container = document.getElementById(id);
         if (container) {
           const resizeObserver = new ResizeObserver(entries => {
-            map.resize();
+            map.resize({ resize: true });
             currentNumberOfMaps = numberOfMaps;
           });
           resizeObserver.observe(container);
@@ -107,7 +107,11 @@
       }
     };
 
-    map.on('move', handleMove);
+    map.on('move', e => {
+      if (!e?.resize) {
+        handleMove(e);
+      }
+    });
   });
 </script>
 

--- a/src/components/MapboxGlMap.svelte
+++ b/src/components/MapboxGlMap.svelte
@@ -19,7 +19,6 @@
 
   let style = {};
   let url;
-  let currentNumberOfMaps = 0;
 
   $: if (mapStyle) ({ style, url } = mapStyle);
 
@@ -49,13 +48,12 @@
 
   // Resize the map when adding more maps and changing container size
   $: {
-    if (map && currentNumberOfMaps !== numberOfMaps) {
+    if (map && numberOfMaps) {
       map.once('render', () => {
         const container = document.getElementById(id);
         if (container) {
           const resizeObserver = new ResizeObserver(() => {
             map.resize({ resize: true });
-            currentNumberOfMaps = numberOfMaps;
           });
           resizeObserver.observe(container);
         }

--- a/src/components/MapboxGlMap.svelte
+++ b/src/components/MapboxGlMap.svelte
@@ -15,9 +15,11 @@
   export let showBoundaries;
   export let zoom;
   export let mapStyle;
+  export let numberOfMaps;
 
   let style = {};
   let url;
+  let currentNumberOfMaps = 0;
 
   $: if (mapStyle) ({ style, url } = mapStyle);
 
@@ -44,6 +46,21 @@
 
   // Show tile boundaries on the map as desired
   $: if (map) map.showTileBoundaries = showBoundaries;
+
+  $: {
+    if (map && currentNumberOfMaps !== numberOfMaps) {
+      map.once('render', () => {
+        const container = document.getElementById(id);
+        if (container) {
+          const resizeObserver = new ResizeObserver(entries => {
+            map.resize();
+            currentNumberOfMaps = numberOfMaps;
+          });
+          resizeObserver.observe(container);
+        }
+      });
+    }
+  }
 
   const getCurrentMapView = () => {
     return {

--- a/src/components/Maps.svelte
+++ b/src/components/Maps.svelte
@@ -1,6 +1,5 @@
 <script>
   import { createEventDispatcher } from 'svelte';
-  import Map from './Map.svelte';
   import MapsMirrorLayout from './MapsMirrorLayout.svelte';
   import MapsPhoneLayout from './MapsPhoneLayout.svelte';
   import MapsSwipeLayout from './MapsSwipeLayout.svelte';

--- a/src/components/MapsMirrorLayout.svelte
+++ b/src/components/MapsMirrorLayout.svelte
@@ -5,9 +5,25 @@
   export let mapState;
 
   let rows = [];
+  let numberOfMaps = 0;
 
-  // Just one row for now, will split into more rows once we can have more than two map panes
   $: rows = [maps];
+
+  $: numberOfMaps = maps.length;
+
+  $: {
+    if (maps.length) {
+      const numOfRows = Math.round(Math.sqrt(numberOfMaps));
+      const mapsPerRow = Math.floor(numberOfMaps / numOfRows);
+      let mapArr = JSON.parse(JSON.stringify(maps));
+      let nextRows = [];
+      while (mapArr.length) {
+        nextRows.push(mapArr.slice(0, mapsPerRow));
+        mapArr = mapArr.slice(mapsPerRow);
+      }
+      rows = nextRows;
+    }
+  }
 </script>
 
 <div class="maps mirror">
@@ -15,7 +31,7 @@
     <div class="row">
       {#each maps as map}
         <div class="map-container">
-          <Map {map} {...mapState} on:mapMove />
+          <Map {map} {...mapState} {numberOfMaps} on:mapMove />
         </div>
       {/each}
     </div>

--- a/src/components/MapsPhoneLayout.svelte
+++ b/src/components/MapsPhoneLayout.svelte
@@ -8,7 +8,13 @@
 <div class="maps phone">
   {#each maps as map}
     <div class="map-container">
-      <Map {map} {...mapState} on:mapMove />
+      <Map
+        {map}
+        {...mapState}
+        themeLabel="map-label-offset"
+        numberOfMaps={maps.length}
+        on:mapMove
+      />
     </div>
   {/each}
 </div>

--- a/src/components/MapsSwipeLayout.svelte
+++ b/src/components/MapsSwipeLayout.svelte
@@ -37,7 +37,7 @@
         ? `clip: rect(0px, ${width}px, ${height}px, ${sliderPosition}px)`
         : null}
     >
-      <Map {map} {...mapState} on:mapMove />
+      <Map {map} {...mapState} numberOfMaps={maps.length} on:mapMove />
     </div>
   {/each}
 

--- a/src/components/ViewModeControl.svelte
+++ b/src/components/ViewModeControl.svelte
@@ -3,14 +3,27 @@
   import { VIEW_MODES } from '../constants';
 
   export let mode;
+  export let mapsNum;
 
   const dispatch = createEventDispatcher();
   let selectedMode = '';
+  let viewModes = VIEW_MODES;
 
   $: selectedMode = mode;
 
   $: if (selectedMode) {
     handleChange();
+  }
+
+  $: {
+    if (mapsNum > 2) {
+      if (selectedMode === 'swipe') selectedMode = 'mirror';
+      viewModes = viewModes.filter(mode => mode !== 'swipe');
+    }
+    if (mapsNum > 4) {
+      if (selectedMode === 'phone') selectedMode = 'mirror';
+      viewModes = viewModes.filter(mode => mode !== 'phone');
+    }
   }
 
   const handleChange = () => {
@@ -20,7 +33,7 @@
 
 <div>
   <select bind:value={selectedMode}>
-    {#each VIEW_MODES as mode}
+    {#each viewModes as mode}
       <option>{mode}</option>
     {/each}
   </select>

--- a/src/components/ViewModeControl.svelte
+++ b/src/components/ViewModeControl.svelte
@@ -16,13 +16,20 @@
   }
 
   $: {
-    if (mapsNum > 2) {
-      if (selectedMode === 'swipe') selectedMode = 'mirror';
-      viewModes = viewModes.filter(mode => mode !== 'swipe');
+    if (mapsNum === 2) {
+      viewModes = VIEW_MODES;
+    }
+    if (mapsNum > 2 && mapsNum <= 4) {
+      viewModes = VIEW_MODES.filter(mode => mode !== 'swipe');
     }
     if (mapsNum > 4) {
-      if (selectedMode === 'phone') selectedMode = 'mirror';
-      viewModes = viewModes.filter(mode => mode !== 'phone');
+      viewModes = VIEW_MODES.filter(
+        mode => mode !== 'swipe' && mode !== 'phone'
+      );
+    }
+
+    if (!viewModes.includes(selectedMode)) {
+      selectedMode = viewModes[0];
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,6 +28,18 @@
   resolved "https://registry.yarnpkg.com/@beyonk/svelte-mapbox/-/svelte-mapbox-8.1.4.tgz#2c52c6c056baa182c5799a3710f0974b579eb25f"
   integrity sha512-H7c5i+iWReb3try5Vk2rIeIXJ6BqmO3eb8OeBntrdKAiKEA0ye7n5t4C13Ne4vvMrfqqzyHuV6kGsM0y/g+lJg==
 
+"@fortawesome/fontawesome-common-types@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz#7dc996042d21fc1ae850e3173b5c67b0549f9105"
+  integrity sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA==
+
+"@fortawesome/free-solid-svg-icons@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz#3369e673f8fe8be2fba30b1ec274d47490a830a6"
+  integrity sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.1.1"
+
 "@googlemaps/js-api-loader@^1.13.10":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.13.10.tgz#499cb58b9dcf8d29101d6d113650b27a55c70ae5"
@@ -1884,6 +1896,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+svelte-fa@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/svelte-fa/-/svelte-fa-2.4.0.tgz#d94285151a975b92b29efec6ec9e2c11c57780ef"
+  integrity sha512-0bnbMGbsE1LUnlioDcf27tl2O8kjuXlTXMXzIxC7LoIOWmqn0D+zd539HfLiQbdLuOHGTaynwN9V+4ehhEu1Jw==
 
 svelte@^3.0.0:
   version "3.46.4"


### PR DESCRIPTION
Closes https://github.com/stamen/map-compare/issues/5

This PR allows up to 8 maps total:
- between 2 and 4 maps can use phone or mirror mode
- greater than 4 maps can only use mirror mode

I limited it at 8 maps because around that point you get `Too many Web GL Context` warnings.

Also worth noting:
When removing Mapbox GL maps, we run `map.remove()` which stops it from using any DOM or GL resources. This lets adding and removing run smoothly with a max of 8 Web GL contexts. 

There doesn't appear to be anything similar with Google maps unfortunately and Google doesn't support use cases like this based on what I could find reading about this online. This means that as an edge case, if you add Google maps, then remove maps, you will get Web GL errors because some of the maps need to reload as opposed to just resizing.

We might be able to resolve this in a followup by restructuring the way we use indexes so that we don't need to reload maps at all. Currently maps reload when they use a different index and name combo which currently represents its uniqueness. This would be a larger refactor.