### PR TITLE
Rtl plugin

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,4 +1,5 @@
 <script>
+  import mapboxgl from 'mapbox-gl';
   import { onMount } from 'svelte';
   import {
     maps as mapsStore,
@@ -83,6 +84,11 @@
       viewMode: event.detail.mode,
     };
   };
+
+  // Set RTL plugin once rather than per map
+  mapboxgl.setRTLTextPlugin(
+    'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js'
+  );
 </script>
 
 <svelte:head>

--- a/src/components/MapStyleInput.svelte
+++ b/src/components/MapStyleInput.svelte
@@ -81,7 +81,7 @@
 
   const poll = url => {
     const pollCondition = str =>
-      str && str.includes('localhost') && selected.url === str;
+      str && str.includes('localhost') && selected?.url === str;
     // Simple polling for any style on localhost
     // Check that should poll to set timer
     if (pollCondition(url)) {


### PR DESCRIPTION
Adds the RTL plugin that allows for using `\n`:
<img width="50%" src="https://user-images.githubusercontent.com/15698320/166505075-e966f823-bf95-453f-b24e-7203691ec11b.png"/><img width="50%" src="https://user-images.githubusercontent.com/15698320/166505090-ba2333d1-a4ed-42d4-98b9-559e056bcf97.png"/>

We had this in a previous version of the compare tool and forgot to add this here.
