### PR TITLE
Fix URL input disappearing

### DIFF
--- a/src/components/MapStyleInput.svelte
+++ b/src/components/MapStyleInput.svelte
@@ -64,7 +64,7 @@
     dropdownOptions = getDropdownOptions();
   };
 
-  $: if (map || stylePresets) {
+  $: if (stylePresets) {
     setSelected();
   }
 
@@ -148,7 +148,7 @@
         ? // TODO We should sort out selected.id and selected.name here, this works but isn't clear
           createBranchUrl(pattern, localUrl, selected.id || selected.name)
         : localUrl;
-    if (selected?.url === nextLocalUrl) return;
+    if (url === nextLocalUrl) return;
     if (nextLocalUrl.includes('localhost')) {
       const [preface, address] = nextLocalUrl.split('localhost');
       // Fetch doesn't accept localhost unless prefaced with http://
@@ -208,6 +208,7 @@
         break;
       }
     }
+    dropdownOptions = getDropdownOptions();
   };
 
   const getDropdownOptions = () => {
@@ -282,7 +283,8 @@
       />
       <button
         use:shortcut={{ code: 'Enter', callback: onKeySubmit }}
-        on:click={submitUrl}>Submit</button
+        on:click={submitUrl}
+        disabled={url === textInput}>Submit</button
       >
     </div>
   {/if}


### PR DESCRIPTION
Closes https://github.com/stamen/map-compare/issues/56

This PR makes some changes for more consistent behavior around custom URLs to prevent the URL input box from disappearing unexpectedly.

Behavior should now be:
- Select a preset option
- Select a custom URL
- See preset option as URL in text field
- Submit button is disabled until changed from current map style
- On changing the URL, allowed to submit
- If changing to a preset style URL, see preset style in select, otherwise see new URL in custom URL box and submit becomes disabled again

@ebrelsford does this behavior seem correct to you?