### PR TITLE
One map responsive

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -60,9 +60,22 @@
   }
 
   $: {
-    const { bearing, center, pitch, showCollisions, showBoundaries, zoom } =
-      settings;
+    const {
+      bearing,
+      center,
+      pitch,
+      showCollisions,
+      showBoundaries,
+      zoom,
+      height,
+      width,
+    } = settings;
+    // Required to be set in state
     mapState = { bearing, center, pitch, showCollisions, showBoundaries, zoom };
+    // May be undefined
+    if (height || width) {
+      mapState = { ...mapState, height, width };
+    }
   }
 
   // Validate map state when maps change too
@@ -85,6 +98,15 @@
     };
   };
 
+  const handleDimensions = event => {
+    console.log(event.detail);
+    settings = {
+      ...settings,
+      ...mapState,
+      ...event.detail,
+    };
+  };
+
   // Set RTL plugin once rather than per map
   mapboxgl.setRTLTextPlugin(
     'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js'
@@ -100,6 +122,7 @@
     {mapState}
     viewMode={settings.viewMode}
     on:mapState={handleMapState}
+    on:setDimensions={handleDimensions}
   />
 
   <div class="map-controls-container">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -106,6 +106,7 @@
     settings = {
       ...settings,
       ...mapState,
+      // contains width and height
       ...event.detail,
     };
   };

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -70,12 +70,16 @@
       height,
       width,
     } = settings;
-    // Required to be set in state
-    mapState = { bearing, center, pitch, showCollisions, showBoundaries, zoom };
-    // May be undefined
-    if (height || width) {
-      mapState = { ...mapState, height, width };
-    }
+    mapState = {
+      bearing,
+      center,
+      pitch,
+      showCollisions,
+      showBoundaries,
+      zoom,
+      ...(height && { height }),
+      ...(width && { width }),
+    };
   }
 
   // Validate map state when maps change too
@@ -99,7 +103,6 @@
   };
 
   const handleDimensions = event => {
-    console.log(event.detail);
     settings = {
       ...settings,
       ...mapState,

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -50,7 +50,7 @@
         index={map.index}
         name={map.name}
         onClose={removeMap}
-        disableClose={numberOfMaps <= 2}
+        disableClose={numberOfMaps <= 1}
       />
     </div>
   </div>
@@ -80,5 +80,9 @@
     left: 0;
     right: 0;
     bottom: unset;
+  }
+
+  .map-label-responsive {
+    position: fixed;
   }
 </style>

--- a/src/components/Maps.svelte
+++ b/src/components/Maps.svelte
@@ -29,6 +29,14 @@
       LayoutComponent = MapsSwipeLayout;
   }
 
+  $: {
+    if (viewMode !== 'responsive' && (mapState.height || mapState.width)) {
+      handleSetDimensions({
+        detail: { options: { height: null, width: null } },
+      });
+    }
+  }
+
   const handleMapMove = event => {
     dispatch('mapState', { options: event.detail.options });
   };

--- a/src/components/Maps.svelte
+++ b/src/components/Maps.svelte
@@ -3,6 +3,7 @@
   import MapsMirrorLayout from './MapsMirrorLayout.svelte';
   import MapsPhoneLayout from './MapsPhoneLayout.svelte';
   import MapsSwipeLayout from './MapsSwipeLayout.svelte';
+  import MapsResponsiveLayout from './MapsResponsiveLayout.svelte';
 
   export let maps;
   export let mapState;
@@ -19,6 +20,9 @@
       break;
     case 'mirror':
       LayoutComponent = MapsMirrorLayout;
+      break;
+    case 'responsive':
+      LayoutComponent = MapsResponsiveLayout;
       break;
     case 'swipe':
     default:

--- a/src/components/Maps.svelte
+++ b/src/components/Maps.svelte
@@ -32,6 +32,10 @@
   const handleMapMove = event => {
     dispatch('mapState', { options: event.detail.options });
   };
+
+  const handleSetDimensions = event => {
+    dispatch('setDimensions', { ...event.detail.options });
+  };
 </script>
 
 <svelte:component
@@ -39,4 +43,5 @@
   {maps}
   {mapState}
   on:mapMove={handleMapMove}
+  on:mapSetDimensions={handleSetDimensions}
 />

--- a/src/components/MapsResponsiveLayout.svelte
+++ b/src/components/MapsResponsiveLayout.svelte
@@ -1,13 +1,16 @@
 <script>
+  import { createEventDispatcher } from 'svelte';
   import Map from './Map.svelte';
 
   export let maps;
   export let mapState;
 
+  const dispatch = createEventDispatcher();
+
   let numberOfMaps = 0;
   let map;
-  let height = '100%';
-  let width = '100%';
+  let height = mapState.height || '100%';
+  let width = mapState.width || '100%';
   let heightInput = '';
   let widthInput = '';
 
@@ -22,11 +25,15 @@
   const setDimensions = () => {
     height = heightInput;
     width = widthInput;
+    dispatch('mapSetDimensions', { options: { height, width } });
   };
 
   const resetDimensions = () => {
     height = '100%';
     width = '100%';
+    heightInput = '';
+    widthInput = '';
+    dispatch('mapSetDimensions', { options: { height: null, width: null } });
   };
 </script>
 
@@ -56,8 +63,13 @@
       </div>
     </div>
     <div class="buttons">
-      <button on:click={setDimensions}>Set Dimensions</button>
-      <button on:click={resetDimensions}>Reset</button>
+      <button on:click={setDimensions} disabled={!widthInput || !heightInput}
+        >Set Dimensions</button
+      >
+      <button
+        on:click={resetDimensions}
+        disabled={height === '100%' && width === '100%'}>Reset</button
+      >
     </div>
   </div>
 </div>

--- a/src/components/MapsResponsiveLayout.svelte
+++ b/src/components/MapsResponsiveLayout.svelte
@@ -11,8 +11,8 @@
   let map;
   let height = mapState.height || '100%';
   let width = mapState.width || '100%';
-  let heightInput = '';
-  let widthInput = '';
+  let heightInput = mapState.height || '';
+  let widthInput = mapState.width || '';
 
   $: {
     if (maps.length) {

--- a/src/components/MapsResponsiveLayout.svelte
+++ b/src/components/MapsResponsiveLayout.svelte
@@ -1,0 +1,131 @@
+<script>
+  import Map from './Map.svelte';
+
+  export let maps;
+  export let mapState;
+
+  let numberOfMaps = 0;
+  let map;
+  let height = '100%';
+  let width = '100%';
+  let heightInput = '';
+  let widthInput = '';
+
+  $: {
+    if (maps.length) {
+      map = maps[0];
+      // For now this should only ever be 1
+      numberOfMaps = maps.length;
+    }
+  }
+
+  const setDimensions = () => {
+    height = heightInput;
+    width = widthInput;
+  };
+
+  const resetDimensions = () => {
+    height = '100%';
+    width = '100%';
+  };
+</script>
+
+<div class="maps responsive">
+  <div class="map-container" style={`height:${height}px; width:${width}px`}>
+    {#if map}
+      <Map
+        {map}
+        {...mapState}
+        {numberOfMaps}
+        themeLabel="map-label-responsive"
+        on:mapMove
+      />
+    {/if}
+  </div>
+  <div class="responsive-input">
+    <div class="dimension-input">
+      <span>Height:</span>
+      <div class="input-container">
+        <input type="number" class="input" bind:value={heightInput} />
+      </div>
+    </div>
+    <div class="dimension-input">
+      <span>Width:</span>
+      <div class="input-container">
+        <input type="number" class="input" bind:value={widthInput} />
+      </div>
+    </div>
+    <div class="buttons">
+      <button on:click={setDimensions}>Set Dimensions</button>
+      <button on:click={resetDimensions}>Reset</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .maps {
+    display: flex;
+    flex-grow: 1;
+    height: 100%;
+    width: 100%;
+    justify-content: center;
+  }
+
+  .map-container {
+    height: 100%;
+    width: 100%;
+    align-self: center;
+    border: 1px solid black;
+  }
+
+  .responsive-input {
+    position: absolute;
+    left: 1em;
+    bottom: 2em;
+    background: white;
+    box-shadow: 0 0 10px 2px rgb(0 0 0 / 10%);
+    padding: 1em;
+    display: flex;
+    flex-direction: column;
+    min-width: 120px;
+    height: auto;
+  }
+
+  .dimension-input {
+    display: flex;
+    width: 100%;
+    height: 36px;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .input-container {
+    display: flex;
+    width: 66px;
+    height: 30px;
+  }
+
+  .input {
+    width: 100%;
+    height: 100%;
+  }
+
+  .buttons {
+    margin-top: 3px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Removes the arrow buttons from number inputs */
+  /* Chrome, Safari, Edge, Opera */
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  input[type='number'] {
+    -moz-appearance: textfield;
+  }
+</style>

--- a/src/components/MapsResponsiveLayout.svelte
+++ b/src/components/MapsResponsiveLayout.svelte
@@ -1,6 +1,7 @@
 <script>
   import { createEventDispatcher } from 'svelte';
   import Map from './Map.svelte';
+  import { shortcut } from '../shortcut';
 
   export let maps;
   export let mapState;
@@ -13,6 +14,8 @@
   let width = mapState.width || '100%';
   let heightInput = mapState.height || '';
   let widthInput = mapState.width || '';
+  let heightInputFocused = false;
+  let widthInputFocused = false;
 
   $: {
     if (maps.length) {
@@ -21,6 +24,14 @@
       numberOfMaps = maps.length;
     }
   }
+
+  const onKeySubmit = () => {
+    const inputFocused = heightInputFocused || widthInputFocused;
+    const disabled = !widthInput || !heightInput;
+    if (inputFocused && !disabled) {
+      setDimensions();
+    }
+  };
 
   const setDimensions = () => {
     height = heightInput;
@@ -53,17 +64,32 @@
     <div class="dimension-input">
       <span>Height:</span>
       <div class="input-container">
-        <input type="number" class="input" bind:value={heightInput} />
+        <input
+          type="number"
+          class="input"
+          bind:value={heightInput}
+          on:focus={() => (heightInputFocused = true)}
+          on:blur={() => (heightInputFocused = false)}
+        />
       </div>
     </div>
     <div class="dimension-input">
       <span>Width:</span>
       <div class="input-container">
-        <input type="number" class="input" bind:value={widthInput} />
+        <input
+          type="number"
+          class="input"
+          bind:value={widthInput}
+          on:focus={() => (widthInputFocused = true)}
+          on:blur={() => (widthInputFocused = false)}
+        />
       </div>
     </div>
     <div class="buttons">
-      <button on:click={setDimensions} disabled={!widthInput || !heightInput}
+      <button
+        on:click={setDimensions}
+        disabled={!widthInput || !heightInput}
+        use:shortcut={{ code: 'Enter', callback: onKeySubmit }}
         >Set Dimensions</button
       >
       <button

--- a/src/components/ViewModeControl.svelte
+++ b/src/components/ViewModeControl.svelte
@@ -16,15 +16,20 @@
   }
 
   $: {
+    if (mapsNum === 1) {
+      viewModes = VIEW_MODES.filter(mode => mode !== 'swipe');
+    }
     if (mapsNum === 2) {
-      viewModes = VIEW_MODES;
+      viewModes = VIEW_MODES.filter(mode => mode !== 'responsive');
     }
     if (mapsNum > 2 && mapsNum <= 4) {
-      viewModes = VIEW_MODES.filter(mode => mode !== 'swipe');
+      viewModes = VIEW_MODES.filter(
+        mode => mode !== 'swipe' && mode !== 'responsive'
+      );
     }
     if (mapsNum > 4) {
       viewModes = VIEW_MODES.filter(
-        mode => mode !== 'swipe' && mode !== 'phone'
+        mode => mode !== 'swipe' && mode !== 'phone' && mode !== 'responsive'
       );
     }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-export const VIEW_MODES = ['swipe', 'mirror', 'phone'];
+export const VIEW_MODES = ['swipe', 'mirror', 'phone', 'responsive'];
 
 export const GOOGLE_MAP_MAX_PITCH_ZOOM_THRESHHOLD = 12;
 export const GOOGLE_MAP_MAX_PITCH_LOW_ZOOM = 35;

--- a/src/query.js
+++ b/src/query.js
@@ -44,12 +44,25 @@ function fromQueryString(qs) {
   return params;
 }
 
+// Remove values set to null
+const cleanSettings = stateObj => {
+  let nextState = Object.keys(stateObj).reduce((acc, k) => {
+    const value = stateObj[k];
+    if (value !== null) acc[k] = value;
+    return acc;
+  }, {});
+  return nextState;
+};
+
 export function writeHash(mapSettings) {
-  const nonMapSettings = Object.fromEntries(
+  let nonMapSettings = Object.fromEntries(
     Object.entries(mapSettings)
       .filter(([k, v]) => !mapLocationKeys.includes(k))
       .map(([k, v]) => [k, jsonKeys.includes(k) ? JSON.stringify(v) : v])
   );
+
+  nonMapSettings = cleanSettings(nonMapSettings);
+
   window.location.hash = toQueryString({
     map: [
       round(mapSettings.zoom, 2),


### PR DESCRIPTION
Closes https://github.com/stamen/map-compare/issues/65
Closes https://github.com/stamen/map-compare/issues/66

This allows a single map pane as well as creates a responsive mode. For now, responsive mode only works when looking at just one map. Width and height are persisted in the URL. 

@ebrelsford I've run into a bug where very occasionally the `maps` array in the URL will reset to blank and I'll see zero maps. This isn't something I can consistently replicate and it's possible it's a preexisting bug to this PR. I'm not sure what is causing this and I can't think of any code here that would have that effect. Please let me know if you run into this and have any hunches.